### PR TITLE
Integrate SonarCloud in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,6 +15,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Set up JDK
         uses: actions/setup-java@v3
@@ -30,8 +32,20 @@ jobs:
           restore-keys: |
             gradle-${{ runner.os }}-
 
+      - name: Cache SonarQube packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.sonar/cache
+          key: ${{ runner.os }}-sonar
+          restore-keys: ${{ runner.os }}-sonar
+
       - name: Grant execute permission for Gradle wrapper
         run: chmod +x gradlew
 
       - name: Run tests
         run: ./gradlew test
+
+      - name: Build and analyze
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        run: ./gradlew build sonar --info

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.android)
+    id("org.sonarqube") version "6.0.1.5171"
 }
 
 android {
@@ -43,4 +44,12 @@ dependencies {
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)
+}
+
+sonar {
+    properties {
+        property("sonar.projectKey", "SE2-Gruppe-5_game-project-frontend")
+        property("sonar.organization", "se2-gruppe-5")
+        property("sonar.host.url", "https://sonarcloud.io")
+    }
 }

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -2,7 +2,7 @@ plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.android)
     jacoco
-    id("org.sonarqube") version "6.0.1.5171"
+    id("org.sonarqube") version "5.1.0.4882"
 }
 
 android {

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -29,8 +29,8 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_11
-        targetCompatibility = JavaVersion.VERSION_11
+        sourceCompatibility = JavaVersion.VERSION_21
+        targetCompatibility = JavaVersion.VERSION_21
     }
     testOptions {
         unitTests {
@@ -40,7 +40,7 @@ android {
         }
     }
     kotlinOptions {
-        jvmTarget = "11"
+        jvmTarget = "21"
     }
 }
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.android)
+    jacoco
     id("org.sonarqube") version "6.0.1.5171"
 }
 
@@ -31,6 +32,13 @@ android {
         sourceCompatibility = JavaVersion.VERSION_11
         targetCompatibility = JavaVersion.VERSION_11
     }
+    testOptions {
+        unitTests {
+            all {
+                it.finalizedBy(tasks.named("jacocoTestReport"))
+            }
+        }
+    }
     kotlinOptions {
         jvmTarget = "11"
     }
@@ -44,6 +52,33 @@ dependencies {
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)
+}
+
+tasks.register<JacocoReport>("jacocoTestReport") {
+    dependsOn(tasks.named("testDebugUnitTest"))
+
+    reports {
+        xml.required = true
+        csv.required = false
+        html.required = false
+    }
+
+    val srcDirs = listOf(
+        "${project.projectDir}/src/main/java",
+        "${project.projectDir}/src/main/kotlin"
+    )
+    val classDirs = listOf(
+        "${project.layout.buildDirectory.get().asFile}/tmp/kotlin-classes/debug",
+        "${project.layout.buildDirectory.get().asFile}/intermediates/javac/debug"
+    )
+    val execData = listOf(
+        "${project.layout.buildDirectory.get().asFile}/jacoco/testDebugUnitTest.exec",
+        "${project.layout.buildDirectory.get().asFile}/outputs/unit_test_code_coverage/debugUnitTest/testDebugUnitTest.exec"
+    )
+
+    sourceDirectories.setFrom(files(srcDirs))
+    classDirectories.setFrom(files(classDirs))
+    executionData.setFrom(files(execData))
 }
 
 sonar {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Sun Mar 23 22:44:15 CET 2025
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
This pull request finally integrates SonarCloud in our continous integration pipeline. A lot of manual changes were necessary compared to the backend, as Android projects have a different structure so JaCoCo will not automatically find the needed test result files.