### PR TITLE
Fixed Android API incompatibilities and local networking

### DIFF
--- a/app/src/debug/AndroidManifest.xml
+++ b/app/src/debug/AndroidManifest.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <application
+        tools:replace="android:networkSecurityConfig"
+        android:networkSecurityConfig="@xml/network_security_config_debug" />
+
+</manifest>

--- a/app/src/debug/AndroidManifest.xml
+++ b/app/src/debug/AndroidManifest.xml
@@ -3,7 +3,9 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <application
-        tools:replace="android:networkSecurityConfig"
-        android:networkSecurityConfig="@xml/network_security_config_debug" />
+        android:allowBackup="true"
+
+        android:networkSecurityConfig="@xml/network_security_config_debug"
+        tools:replace="android:networkSecurityConfig" />
 
 </manifest>

--- a/app/src/debug/AndroidManifest.xml
+++ b/app/src/debug/AndroidManifest.xml
@@ -4,6 +4,9 @@
 
     <application
         android:allowBackup="true"
+        android:dataExtractionRules="@xml/data_extraction_rules"
+        android:fullBackupContent="@xml/backup_rules"
+        android:icon="@mipmap/ic_launcher"
 
         android:networkSecurityConfig="@xml/network_security_config_debug"
         tools:replace="android:networkSecurityConfig" />

--- a/app/src/debug/res/xml/network_security_config_debug.xml
+++ b/app/src/debug/res/xml/network_security_config_debug.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <network-security-config>
-
+    <base-config cleartextTrafficPermitted="true" />
 </network-security-config>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -4,7 +4,6 @@
 
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE"/>
     <uses-permission android:name="android.permission.INTERNET"/>
-    <!-- Remove networksecurity Config setting, only for localhost testing-->
     <application
         android:usesCleartextTraffic="false"
         android:allowBackup="true"

--- a/app/src/main/java/com/se2gruppe5/risikofrontend/game/GameActivity.kt
+++ b/app/src/main/java/com/se2gruppe5/risikofrontend/game/GameActivity.kt
@@ -30,12 +30,12 @@ import com.se2gruppe5.risikofrontend.network.sse.messages.UpdatePlayersMessage
 import kotlinx.coroutines.runBlocking
 import java.util.UUID
 import android.util.Log
-import androidx.annotation.RequiresApi
 import com.se2gruppe5.risikofrontend.game.dataclasses.PlayerRecord
 import com.se2gruppe5.risikofrontend.game.managers.GameViewManager
 import com.se2gruppe5.risikofrontend.game.managers.TerritoryManager
 import com.se2gruppe5.risikofrontend.game.territory.PointingArrowAndroid
 import com.se2gruppe5.risikofrontend.network.sse.messages.GameStartMessage
+import java.io.Serializable
 
 
 class GameActivity : AppCompatActivity() {
@@ -65,15 +65,16 @@ class GameActivity : AppCompatActivity() {
     var turnIndicators: MutableList<TextView> = mutableListOf()
     var gameManager: GameManager? = null
     var gameID: UUID? = null
-    @RequiresApi(Build.VERSION_CODES.TIRAMISU)
+
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_SENSOR_LANDSCAPE
         enableEdgeToEdge()
         setContentView(R.layout.game)
 
-        val gameStart = intent.getSerializableExtra("GAME_DATA", GameStartMessage::class.java)!!
-        val me = intent.getSerializableExtra("LOCAL_PLAYER", PlayerRecord::class.java)!!
+        val gameStart = getSerializableExtraCompat(intent, "GAME_DATA", GameStartMessage::class.java)!!
+        val me = getSerializableExtraCompat(intent, "LOCAL_PLAYER", PlayerRecord::class.java)!!
 
         gameID = gameStart.gameId
 
@@ -202,6 +203,18 @@ class GameActivity : AppCompatActivity() {
 
         }
 
+    }
+
+    /**
+    Workaround for using getSerializableExtra on all Android versions
+    **/
+    private fun <T: Serializable> getSerializableExtraCompat(intent: Intent, varName: String, retClass: Class<T>): T? {
+        if (Build.VERSION.SDK_INT>=33) {
+            return intent.getSerializableExtra(varName, retClass)
+        }
+
+        @Suppress("DEPRECATION", "UNCHECKED_CAST")
+        return intent.getSerializableExtra(varName) as? T
     }
 
 


### PR DESCRIPTION
This PR fixes the critical error caused by API versions < 33 due to `getSerializableExtra` with type-safety only being available then.

Additionally it also fixes networking when testing with a local server, since the previously used wildcard solution didn't actually work. The new approach also drops the workaround in the main manifest and moves it to a debug manifest so that release builds will enforce secure communication but debug builds are allowed cleartext communication (so we can test on local servers, and don't need proper deployment). This means we don't need to remember to remove anything - the builds will reflect this automatically.