### PR TITLE
Added remaining proper exclusions for Sonar

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -172,6 +172,8 @@ sonar {
                 "**/com/se2gruppe5/risikofrontend/startmenu/**",
                 "**/com/se2gruppe5/risikofrontend/MainActivity.kt",
                 "**/com/se2gruppe5/risikofrontend/game/GameActivity.kt",
+                "**/com/se2gruppe5/risikofrontend/game/ReinforcementActivity.kt",
+                "**/com/se2gruppe5/risikofrontend/game/TroopNumberAdapter.kt",
                 "**/com/se2gruppe5/risikofrontend/game/board/BoardJsonClasses.kt",
                 "**/com/se2gruppe5/risikofrontend/game/board/BoardLoaderAndroid.kt",
                 "**/com/se2gruppe5/risikofrontend/game/board/BoardVisualGeneratorAndroid.kt",


### PR DESCRIPTION
Two major classes, `ReinforcementActivity` (which is, as the name suggests, an activity) and `TroopNumberAdapter` (which handles UI specifics) weren't excluded from Sonar coverage yet even though they should be according to Lercher on 28/4/25. This PR should finally bring our coverage up to scratch again as now all relevant classes are be included, and all irrelevant classes are excluded as far as I can tell.